### PR TITLE
feat/pipeline-publish-extend

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -28,7 +28,15 @@ jobs:
       - name: Run clippy
         run: cargo clippy -- -D warnings
 
-      - name: Publish to crates.io
-        run: cargo publish --token ${CRATES_TOKEN}
+      - name: Publish sqlx-paginated-derive to crates.io
+        run: cargo publish -p sqlx-paginated-derive --token ${CRATES_TOKEN}
+        env:
+          CRATES_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+
+      - name: Wait for crates.io index to catch up
+        run: sleep 30
+
+      - name: Publish sqlx-paginated to crates.io
+        run: cargo publish -p sqlx-paginated --token ${CRATES_TOKEN}
         env:
           CRATES_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}

--- a/crates/sqlx-paginated/Cargo.toml
+++ b/crates/sqlx-paginated/Cargo.toml
@@ -12,14 +12,14 @@ documentation.workspace = true
 tracing = ["tracing/default"]
 postgres = ["sqlx/postgres"]
 sqlite = ["sqlx/sqlite"]
-mysql = ["sqlx/mysql"] # Planned - Q2 2026
+mysql = ["sqlx/mysql"] # Planned - Q3 2026
 default = ["postgres"]
 
 [lib]
 path = "src/lib.rs"
 
 [dependencies]
-sqlx-paginated-derive = { path = "../sqlx-paginated-derive" }
+sqlx-paginated-derive = { path = "../sqlx-paginated-derive", version = "0.6.0" }
 sqlx = { version = "0.9.0", default-features = false, features = [
     "runtime-tokio",
     "tls-rustls",

--- a/examples/sqlx-paginated-sqlite-example/Cargo.toml
+++ b/examples/sqlx-paginated-sqlite-example/Cargo.toml
@@ -3,6 +3,7 @@ name = "sqlx-paginated-sqlite-example"
 version = "0.1.0"
 edition = "2021"
 license = "MIT"
+publish = false
 
 [dependencies]
 anyhow = "1.0"


### PR DESCRIPTION
Extend publish workflow for the `sqlx-paginated-derive` crate